### PR TITLE
Fix auth.users permission for profile policies

### DIFF
--- a/supabase/20250711075529_flat_grove.sql
+++ b/supabase/20250711075529_flat_grove.sql
@@ -209,3 +209,7 @@ CREATE TRIGGER update_user_profiles_updated_at
   BEFORE UPDATE ON user_profiles
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
+
+-- Allow policies that reference auth.users to run for authenticated sessions
+GRANT USAGE ON SCHEMA auth TO authenticated;
+GRANT SELECT ON TABLE auth.users TO authenticated;

--- a/supabase/migrations/20250711075529_flat_grove.sql
+++ b/supabase/migrations/20250711075529_flat_grove.sql
@@ -209,3 +209,7 @@ CREATE TRIGGER update_user_profiles_updated_at
   BEFORE UPDATE ON user_profiles
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
+
+-- Allow policies that reference auth.users to run for authenticated sessions
+GRANT USAGE ON SCHEMA auth TO authenticated;
+GRANT SELECT ON TABLE auth.users TO authenticated;


### PR DESCRIPTION
## Summary
- update Supabase migrations to allow `authenticated` role to read `auth.users`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6870f87738b483269dee59ba4f17ac08